### PR TITLE
Golden Repo PR Changes: Changed UserPage annotation fetching

### DIFF
--- a/app/controllers/saasbook_controller.rb
+++ b/app/controllers/saasbook_controller.rb
@@ -27,6 +27,10 @@ class SaasbookController < ApplicationController
   def show_section
     @chapter_id = params[:chapter_id]
     @section_id = params[:section_id]
+    if Integer(@section_id) <= 0
+      redirect_to chapter_path(chapter_id: @chapter_id)
+      return
+    end
     @title = Page.where(chapter: @chapter_id, section: @section_id)[0].title
     @title = "#{@chapter_id}.#{@section_id}. #{@title}"
     @body_contents = "chapter#{@chapter_id}section#{@section_id}"
@@ -64,8 +68,13 @@ class SaasbookController < ApplicationController
   def annotate
     return unless user_signed_in?
 
+    @page = Page.where(chapter: @chapter, section: @section)
+    # Ensures this is a valid page
+    return if @page.nil?
+
+    @page = @page.first
     @anno = @user.page_annotations.where(chapter: @chapter, section: @section).first_or_create
-    @anno.update(annotation: params[:annotation])
+    @anno.update(annotation: params[:annotation], page: @page)
   end
 
   def fetch_annotations

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,10 +18,13 @@ class UsersController < ApplicationController
   def get_path_from_page(page)
     @section = page.section
     @chapter = page.chapter
-    home_path if @chapter.zero? && @section.zero?
-    preface_path if @chapter.zero? && @section.negative?
-    chapter_path(chapter_id: @chapter) if @chapter.positive? && @section.zero?
+    special_path_handler(@section) if @chapter.zero?
     section_path(chapter_id: @chapter, section_id: @section) if @chapter.positive? && @section.positive?
+  end
+
+  def special_path_handler(section)
+    home_path if section.zero?
+    preface_path if section.negative?
   end
 
   # Returns a page title given a page object

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
     @section = page.section
     @chapter = page.chapter
     home_path if @chapter.zero? && @section.zero?
-    preface_path if @chapter.zero?
+    preface_path if @chapter.zero? && @section.negative?
     chapter_path(chapter_id: @chapter) if @chapter.positive? && @section.zero?
     section_path(chapter_id: @chapter, section_id: @section) if @chapter.positive? && @section.positive?
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,10 +36,12 @@ class UsersController < ApplicationController
   def get_title_from_page(page)
     @section = page.section
     @chapter = page.chapter
-    if @chapter.positive? && @section.positive?
-      "#{@chapter}.#{@section} #{page.title}"
-    elsif @chapter.positive?
-      "#{@chapter}.0 #{page.title}"
+    if @chapter.positive? 
+      if @section.positive?
+        "#{@chapter}.#{@section} #{page.title}"
+      else
+        "#{@chapter}.0 #{page.title}"
+      end
     else
       page.title
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,17 +18,10 @@ class UsersController < ApplicationController
   def get_path_from_page(page)
     @section = page.section
     @chapter = page.chapter
-    if @chapter.zero?
-      if @section.zero?
-        home_path
-      else
-        preface_path
-      end
-    elsif @section.zero?
-      chapter_path(chapter_id: @chapter)
-    else
-      section_path(chapter_id: @chapter, section_id: @section)
-    end
+    home_path if @chapter.zero? && @section.zero?
+    preface_path if @chapter.zero?
+    chapter_path(chapter_id: @chapter) if @chapter.positive? && @section.zero?
+    section_path(chapter_id: @chapter, section_id: @section) if @chapter.positive? && @section.positive?
   end
 
   # Returns a page title given a page object

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,14 +18,14 @@ class UsersController < ApplicationController
   def get_path_from_page(page)
     @section = page.section
     @chapter = page.chapter
-    if @section.zero?
-      if @chapter.zero?
+    if @chapter.zero?
+      if @section.zero?
         home_path
       else
-        chapter_path(chapter_id: @chapter)
+        preface_path
       end
-    elsif @chapter.zero?
-      preface_path
+    elsif @section.zero?
+      chapter_path(chapter_id: @chapter)
     else
       section_path(chapter_id: @chapter, section_id: @section)
     end
@@ -36,7 +36,7 @@ class UsersController < ApplicationController
   def get_title_from_page(page)
     @section = page.section
     @chapter = page.chapter
-    if @chapter.positive? 
+    if @chapter.positive?
       if @section.positive?
         "#{@chapter}.#{@section} #{page.title}"
       else

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Page < ApplicationRecord
+  has_many :page_annotations
 end

--- a/app/models/page_annotation.rb
+++ b/app/models/page_annotation.rb
@@ -2,4 +2,5 @@
 
 class PageAnnotation < ApplicationRecord
   belongs_to :user
+  belongs_to :page
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
     where(provider: provider_data.provider, uid: provider_data.uid).first_or_create do |user|
       user.email = provider_data.info.email
       user.password = Devise.friendly_token[0, 20]
-      user.nickname = provider_data.info.name
+      user.nickname = provider_data.info.nickname
     end
   end
 end

--- a/app/views/users/_user_page.html.erb
+++ b/app/views/users/_user_page.html.erb
@@ -5,7 +5,7 @@
         <%= image_tag "http://github.com/#{current_user.nickname}.png", width: "50%" %>
     </div>
     <div class="col-12 col-md-4 text-center">
-        <h1><%= @user.nickname %></h1>
+        <h1><%= current_user.nickname %></h1>
     </div>
     <div class="col-12 col-md-2 text-center">
             <%= button_to "Sign out", destroy_user_session_path, method: :delete, class: "btn btn-outline-primary" %>
@@ -22,23 +22,14 @@
             </tr>
         </thead>
         <tbody>
-            <% @annotations.each do |x| %>
-            <% next if eval(x.annotation).empty? %>
-                <tr>
-                    <% if x.section == 0 %>
-                        <% if x.chapter == 0 %>
-                            <td><%= link_to "Home", home_path() %></td>
-                        <% else %>
-                            <td><%= link_to "#{x.chapter}. #{Page.where(chapter: x.chapter, section: x.section)[0].title}", chapter_path(chapter_id: x.chapter) %></td>
-                        <% end %>
-                    <% else %>
-                        <% if x.chapter == 0 %>
-                            <td><%= link_to "Preface", preface_path() %></td>
-                        <% else %>
-                            <td><%= link_to "#{x.chapter}.#{x.section}. #{Page.where(chapter: x.chapter, section: x.section)[0].title}", section_path(chapter_id: x.chapter, section_id: x.section) %></td>
-                        <% end %>
-                    <% end %> 
-                </tr>
+            <% if @anno_nodes.empty? %>
+                <tr><td>You have not made any annotations!</td></tr>
+            <% else %>
+                <% @anno_nodes.each do |x| %>
+                    <tr>
+                        <td><%= link_to x.title, x.link %></td>
+                    </tr>
+                <% end %>
             <% end %>
         </tbody>
     </table>

--- a/db/migrate/20220501204721_add_page_to_page_annotation.rb
+++ b/db/migrate/20220501204721_add_page_to_page_annotation.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Adds a page reference to the page annotations table
+class AddPageToPageAnnotation < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :page_annotations, :page, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_220_425_054_309) do
+ActiveRecord::Schema.define(version: 20_220_501_204_721) do
   create_table 'page_annotations', force: :cascade do |t|
     t.integer 'chapter'
     t.integer 'section'
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20_220_425_054_309) do
     t.integer 'user_id'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
+    t.integer 'page_id', null: false
+    t.index ['page_id'], name: 'index_page_annotations_on_page_id'
     t.index ['user_id'], name: 'index_page_annotations_on_user_id'
   end
 
@@ -52,4 +54,6 @@ ActiveRecord::Schema.define(version: 20_220_425_054_309) do
     t.datetime 'updated_at', precision: 6, null: false
     t.index ['email'], name: 'index_users_on_email', unique: true
   end
+
+  add_foreign_key 'page_annotations', 'pages'
 end

--- a/spec/controllers/users_spec.rb
+++ b/spec/controllers/users_spec.rb
@@ -10,10 +10,56 @@ RSpec.describe UsersController, type: :controller do
     describe 'success' do
       login_user
       it 'should show username' do
-        @user = User.find_by(uid: 43_231, provider: 'github')
         get :profile
         expect(response).not_to be_nil
         expect(response.body).to include('Gob Github')
+      end
+    end
+  end
+  context 'page path helper' do
+    render_views
+    describe 'Having an annotation on the home page' do
+      login_user
+      it 'should show the title of the home page' do
+        @user = User.first
+        @page = Page.create(chapter: 0, section: 0, title: 'This is the home page title now')
+        @test_annotation = @user.page_annotations.create(chapter: '0', section: '0', annotation: 'hi', page: @page)
+        get :profile
+        expect(response).to be_successful
+        expect(response.body).to include('This is the home page title now')
+      end
+    end
+    describe 'Having an annotation on the preface page' do
+      login_user
+      it 'should show the title of the preface page' do
+        @user = User.first
+        @page = Page.create(chapter: 0, section: 1, title: 'This is the preface page title now')
+        @test_annotation = @user.page_annotations.create(chapter: '0', section: '1', annotation: 'hi', page: @page)
+        get :profile
+        expect(response).to be_successful
+        expect(response.body).to include('This is the preface page title now')
+      end
+    end
+    describe 'Having an annotation on a normal chapter/section page' do
+      login_user
+      it 'should show the title of the page, along with chapter.section indicator page' do
+        @user = User.first
+        @page = Page.create(chapter: 4, section: 5, title: 'MyFavoritePageTitle')
+        @test_annotation = @user.page_annotations.create(chapter: '4', section: '5', annotation: 'hi', page: @page)
+        get :profile
+        expect(response).to be_successful
+        expect(response.body).to include('4.5 MyFavoritePageTitle')
+      end
+    end
+    describe 'Having an annotation on a chapter page' do
+      login_user
+      it 'should show the title of the page, along with chapter.section indicator page' do
+        @user = User.first
+        @page = Page.create(chapter: 4, section: 0, title: 'MyFavoritePageTitle')
+        @test_annotation = @user.page_annotations.create(chapter: '4', section: '0', annotation: 'hi', page: @page)
+        get :profile
+        expect(response).to be_successful
+        expect(response.body).to include('4.0 MyFavoritePageTitle')
       end
     end
   end

--- a/spec/models/user_model_spec.rb
+++ b/spec/models/user_model_spec.rb
@@ -8,7 +8,7 @@ describe User do
   describe 'Using create_from_provider_data Method on an existing user' do
     it 'should return the applicable user' do
       @test_user = FactoryBot.create(:user)
-      @test_data = double(provider: 'github', uid: 43_231)
+      @test_data = double(provider: 'github', uid: 43_231, nickname: 'GGHub')
       @found_user = User.create_from_provider_data(@test_data)
       expect(@found_user).to eq(@test_user)
     end
@@ -19,7 +19,7 @@ describe User do
       @found_user = User.find_by(uid: 1337, provider: 'github')
       expect(@found_user).not_to be_present
       # Set up some doubles
-      @test_info = double(email: 'Will Smith', name: 'Will')
+      @test_info = double(email: 'Will Smith', nickname: 'Will')
       @test_data = double(provider: 'github', uid: 1337, info: @test_info)
       # Test the actual method
       @created_user = User.create_from_provider_data(@test_data)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,7 +76,8 @@ RSpec.configure do |config|
                                                                 provider: 'github',
                                                                 uid: '123545',
                                                                 email: 'githubs@testing.com',
-                                                                full_name: 'bob bobson'
+                                                                nickname: 'GGHub',
+                                                                full_name: 'Gob Github'
                                                               })
 
   # Factorybot

--- a/spec/requests/chapter_section_spec.rb
+++ b/spec/requests/chapter_section_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe 'Chapter and Section Requests', type: :request do
       assert_select 'span.section-number', '1.'
     end
   end
+  describe 'GET section with a negative section number' do
+    it 'Succeeeds and redirects to the chapter page' do
+      get section_path(chapter_id: 1, section_id: -1)
+      expect(response.status).to eq(302)
+      response.should redirect_to chapter_path(chapter_id: 1)
+    end
+  end
 end
 
 RSpec.describe 'Index and Preface Requests', type: :request do


### PR DESCRIPTION
Changes:

- Changed how PageAnnotations associate with Pages. PageAnnotations now belongs_to Page! By leveraging this relationship we can enforce that annotations are only created for valid pages (prevents DDOS by users creating annotations for pages that don't exist)
- Wrote helper methods in the user controller to help fetch the route and title for particular annotations. I don't really like that we are storing them in the user controller (doesn't make a whole lot of sense), but they are only used from the user profile page and that page is being served from that controller so... Maybe there is some Rails-ey way to implement shared helper methods.
- BUGFIX: The user model was looking for the info.name response from github to render name and avatar; github actually provides info.nickname for that purpose. This necessitated changing the user model as well as the user tests.
- Wrote tests for fetching the annotations to serve to the user page.
- Added functionality to the section_path route: if you put in a section path <= 0, redirects you to the chapter path. This was originally going to serve some function, but I took a different route (so to speak). I left this functionality in because you never know if a user is going to put section/0 in their browser, and it's nicer to redirect to chapter heading than to error.