### PR TITLE
CSS lint fixes

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -1,31 +1,40 @@
-.myCustomHighlight {
-    background-color: lime !important;
-    color: red;
-}
-
 .highlight_button {
     padding: 2px;
     width: 120px;
 }
 
-.yellow-highlight {
-    background-color: #ffff80 !important;
-    color: black;
-}
-.green-highlight {
-    background-color: #8cff32 !important;
-    color: black;
-}
-.blue-highlight {
-    background-color: #add8e6 !important;
-    color: black;
-}
-.default-annotation {
-    background-color: lavender !important;
+span.yellow-highlight {
+    background-color: #ffff80;
     color: black;
 }
 
-.dropdown-menu {
+span.green-highlight {
+    background-color: #8cff32;
+    color: black;
+}
+
+span.blue-highlight {
+    background-color: #add8e6;
+    color: black;
+}
+
+span.default-annotation {
+    background-color: lavender;
+    color: black;
+}
+
+/* 
+    PLEASE NOTE: !important must be used here.
+    Bootstrap injects element.style tag directly
+    into the HTML for these dropdowns.
+    No amount of specificity will override it.
+
+    If the options are adding a bunch of javascript
+    to try to intercept/override the style injected
+    by bootstrap or just add !important to the CSS,
+    I'll take the hit on the CSS.
+*/
+div#color-dropdown.dropdown-menu.show {
     transform: translate(0px, 36px) !important;
 }
 

--- a/app/assets/stylesheets/image.css
+++ b/app/assets/stylesheets/image.css
@@ -1,25 +1,16 @@
-/*
-for figures
-*/
-
 .center {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  width: 75%;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 75%;
 }
-
-/* figure {
-  display: inline-block;
-  width: 50%;
-  text-align: center;
-} */
 
 figure img {
-  vertical-align: top;
+    vertical-align: top;
 }
+
 figure figcaption {
-  font-weight: bold;
-  text-align: center;
-  font-size:12px;
+    font-weight: bold;
+    text-align: center;
+    font-size: 12px;
 }


### PR DESCRIPTION
- Fixed some CSS nitpicks.
- Increased specificity on highlight tags to remove the need for the !important declaration. 

Please note, there was one item that we could not remove !important from. This is because we are using bootstrap, which inserts style attributes directly into the HTML tag - no amount of specificity can override that. The choice was either to write javascript to run after the bootstrap code (somehow) to remove the style attribute.... or just keep in the !important tag.